### PR TITLE
install_requires=[ "regex" ],

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     url='https://github.com/neouyghur/ScriptConverter4Uyghur',
     packages=find_packages(),
     install_requires=[
+        "regex"
     ],
     classifiers=[
         # Trove classifiers to categorize the package (https://pypi.org/classifiers/)


### PR DESCRIPTION
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\arthu\AppData\Local\Programs\Python\Python312\Lib\site-packages\umsc\__init__.py", line 1, in <module>
    from .umsc import UgMultiScriptConverter
  File "C:\Users\arthu\AppData\Local\Programs\Python\Python312\Lib\site-packages\umsc\umsc.py", line 27, in <module>
    import regex as re
ModuleNotFoundError: No module named 'regex'